### PR TITLE
change default port name when running on Windows

### DIFF
--- a/rosserial_arduino/nodes/serial_node.py
+++ b/rosserial_arduino/nodes/serial_node.py
@@ -34,6 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import rospy
+import platform
 from rosserial_arduino import SerialClient
 from serial import SerialException
 from time import sleep
@@ -45,8 +46,8 @@ if __name__=="__main__":
     rospy.init_node("serial_node")
     rospy.loginfo("ROS Serial Python Node")
 
-    port_name = rospy.get_param('~port','/dev/ttyUSB0')
-    baud = int(rospy.get_param('~baud','57600'))
+    port_name = rospy.get_param('~port', 'COM1' if platform.system() == 'Windows' else '/dev/ttyUSB0')
+    baud = int(rospy.get_param('~baud', '57600'))
 
     # Number of seconds of sync failure after which Arduino is auto-reset.
     # 0 = no timeout, auto-reset disabled

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -36,6 +36,7 @@
 __author__ = "mferguson@willowgarage.com (Michael Ferguson)"
 
 import rospy
+import platform
 from rosserial_python import SerialClient, RosSerialServer
 from serial import SerialException
 from time import sleep

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -48,8 +48,8 @@ if __name__=="__main__":
     rospy.init_node("serial_node")
     rospy.loginfo("ROS Serial Python Node")
 
-    port_name = rospy.get_param('~port','/dev/ttyUSB0')
-    baud = int(rospy.get_param('~baud','57600'))
+    port_name = rospy.get_param('~port', 'COM1' if platform.system() == 'Windows' else '/dev/ttyUSB0')
+    baud = int(rospy.get_param('~baud', '57600'))
 
     # for systems where pyserial yields errors in the fcntl.ioctl(self.fd, TIOCMBIS, \
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port


### PR DESCRIPTION
Windows uses `COM1`, `COM2`, ... while Linux uses `/dev/ttyUSB0`, etc.